### PR TITLE
Create SkillContext with updated HTML skill data

### DIFF
--- a/skill-analytics-dashboard/src/app/layout.js
+++ b/skill-analytics-dashboard/src/app/layout.js
@@ -1,5 +1,6 @@
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
+import { SkillProvider } from '../context/SkillContext';
 import './globals.css';
 
 export const metadata = {
@@ -14,7 +15,9 @@ export default function RootLayout({ children }) {
         <Header />
         <div className="flex">
           <Sidebar />
-          <main className="flex-1 p-4">{children}</main>
+          <main className="flex-1 p-4">
+            <SkillProvider>{children}</SkillProvider>
+          </main>
         </div>
       </body>
     </html>

--- a/skill-analytics-dashboard/src/context/SkillContext.js
+++ b/skill-analytics-dashboard/src/context/SkillContext.js
@@ -1,0 +1,16 @@
+"use client";
+
+import { createContext, useState } from 'react';
+import { skillData } from '../data/skillData';
+
+export const SkillContext = createContext();
+
+export const SkillProvider = ({ children }) => {
+  const [skills, setSkills] = useState(skillData);
+
+  return (
+    <SkillContext.Provider value={{ skills, setSkills }}>
+      {children}
+    </SkillContext.Provider>
+  );
+};

--- a/skill-analytics-dashboard/src/data/skillData.js
+++ b/skill-analytics-dashboard/src/data/skillData.js
@@ -1,0 +1,20 @@
+export const skillData = [
+  {
+    id: 1,
+    name: 'HTML',
+    icon: '/html-icon.png',
+    totalQuestions: 15,
+    duration: '30 mins',
+    submittedDate: '2025-04-25',
+    rank: 120,
+    percentile: 30, 
+    correctAnswers: 10,
+    syllabus: [
+      { topic: 'Basics & Syntax', percentage: 70 },
+      { topic: 'Forms & Inputs', percentage: 80 },
+      { topic: 'Semantics & Structure', percentage: 65 },
+      { topic: 'Media & Embedding', percentage: 55 },
+      { topic: 'Tables & Lists', percentage: 60 },
+    ],
+  },
+];


### PR DESCRIPTION
* Created skillData.js with a single skill entry for HTML, including 5 sub-topics (Basics & Syntax, Forms & Inputs, Semantics & Structure, Media & Embedding, Tables & Lists) with their respective percentiles (e.g., Forms & Inputs at 80%, Tables & Lists at 60%).

* Set HTML's overall percentile to 30%, with other fields like totalQuestions, duration, rank, and correctAnswers.

* Created SkillContext to manage the skill data with state, allowing updates via setSkills (for the Update button functionality).

* Updated RootLayout to wrap children with SkillProvider, making SkillContext available to all components.

* This sets up the data foundation for the Skill Test section.

