### PR TITLE
add skill-test page and  placeholder components to fix invalid elemen…

### DIFF
--- a/skill-analytics-dashboard/src/app/skill-test/page.js
+++ b/skill-analytics-dashboard/src/app/skill-test/page.js
@@ -1,0 +1,34 @@
+"use client";
+
+import { useContext } from 'react';
+import { SkillContext } from '../../context/SkillContext';
+import SkillOverview from '../../components/SkillOverview';
+import QuickStatistics from '../../components/QuickStatistics';
+import ComparisonGraph from '../../components/ComparisonGraph';
+import SyllabusAnalysis from '../../components/SyllabusAnalysis';
+import QuestionAnalysis from '../../components/QuestionAnalysis';
+
+export default function SkillTest() {
+  const { skills } = useContext(SkillContext);
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Skill Test Analytics Dashboard</h1>
+      {skills.map((skill) => (
+        <div key={skill.id} className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="md:col-span-2 space-y-4">
+              <SkillOverview skill={skill} />
+              <QuickStatistics skill={skill} />
+              <ComparisonGraph skill={skill} />
+            </div>
+            <div className="space-y-4">
+              <SyllabusAnalysis skill={skill} />
+              <QuestionAnalysis skill={skill} />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/skill-analytics-dashboard/src/components/ComparisonGraph.js
+++ b/skill-analytics-dashboard/src/components/ComparisonGraph.js
@@ -1,0 +1,10 @@
+const ComparisonGraph = ({ skill }) => {
+    return (
+      <div>
+        <h3>Comparison Graph (Placeholder)</h3>
+        <p>Percentile: {skill.percentile}%</p>
+      </div>
+    );
+  };
+  
+  export default ComparisonGraph;

--- a/skill-analytics-dashboard/src/components/QuestionAnalysis.js
+++ b/skill-analytics-dashboard/src/components/QuestionAnalysis.js
@@ -1,0 +1,10 @@
+const QuestionAnalysis = ({ skill }) => {
+    return (
+      <div>
+        <h3>Question Analysis (Placeholder)</h3>
+        <p>Correct Answers: {skill.correctAnswers}/{skill.totalQuestions}</p>
+      </div>
+    );
+  };
+  
+  export default QuestionAnalysis;

--- a/skill-analytics-dashboard/src/components/QuickStatistics.js
+++ b/skill-analytics-dashboard/src/components/QuickStatistics.js
@@ -1,0 +1,10 @@
+const QuickStatistics = ({ skill }) => {
+    return (
+      <div>
+        <h3>Quick Statistics (Placeholder)</h3>
+        <p>Rank: {skill.rank}</p>
+      </div>
+    );
+  };
+  
+  export default QuickStatistics;

--- a/skill-analytics-dashboard/src/components/SkillOverview.js
+++ b/skill-analytics-dashboard/src/components/SkillOverview.js
@@ -1,0 +1,10 @@
+const SkillOverview = ({ skill }) => {
+    return (
+      <div>
+        <h3>Skill Overview (Placeholder)</h3>
+        <p>Skill: {skill.name}</p>
+      </div>
+    );
+  };
+  
+  export default SkillOverview;

--- a/skill-analytics-dashboard/src/components/SyllabusAnalysis.js
+++ b/skill-analytics-dashboard/src/components/SyllabusAnalysis.js
@@ -1,0 +1,10 @@
+const SyllabusAnalysis = ({ skill }) => {
+    return (
+      <div>
+        <h3>Syllabus Analysis (Placeholder)</h3>
+        <p>Topics: {skill.syllabus.map((item) => item.topic).join(', ')}</p>
+      </div>
+    );
+  };
+  
+  export default SyllabusAnalysis;


### PR DESCRIPTION
…t type error

* Built SkillTest page to display analytics for the HTML skill test using data from SkillContext.

* Used map to dynamically render skill test components, ensuring scalability (currently renders one skill: HTML).

* Structured the layout with a responsive grid: 2 columns on the left (SkillOverview, QuickStatistics, ComparisonGraph) and 1 column on the right (SyllabusAnalysis, QuestionAnalysis).

* Added key prop to map loop for React best practices."

* Created placeholder implementations for SkillOverview, QuickStatistics, ComparisonGraph, SyllabusAnalysis, and QuestionAnalysis components.

* Each component has a proper export default statement to match the default imports in SkillTest.

* 
![Uploading Screenshot 2025-04-30 125333.png…]()
This resolves the 'Element type is invalid' error by ensuring all imported components are defined and exported correctly."

