### PR TITLE
Finalize styling fixes in SkillOverview component

### DIFF
--- a/skill-analytics-dashboard/src/components/SkillOverview.js
+++ b/skill-analytics-dashboard/src/components/SkillOverview.js
@@ -1,10 +1,128 @@
+"use client";
+
+import Image from 'next/image';
+import { useState, useContext } from 'react';
+import { SkillContext } from '../context/SkillContext';
+
 const SkillOverview = ({ skill }) => {
-    return (
-      <div>
-        <h3>Skill Overview (Placeholder)</h3>
-        <p>Skill: {skill.name}</p>
-      </div>
-    );
+  const { skills, setSkills } = useContext(SkillContext);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formData, setFormData] = useState({
+    rank: skill.rank,
+    percentile: skill.percentile,
+    correctAnswers: skill.correctAnswers,
+  });
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: parseInt(value) });
   };
-  
-  export default SkillOverview;
+
+  const handleSave = () => {
+    const updatedSkills = skills.map((s) =>
+      s.id === skill.id ? { ...s, ...formData } : s
+    );
+    setSkills(updatedSkills);
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div className="p-4 border rounded-lg shadow-sm bg-white">
+      <div className="flex items-center">
+        <div className="flex items-center">
+          <Image
+            src={skill.icon}
+            alt={`${skill.name} Icon`}
+            width={40}
+            height={40}
+            className="object-contain"
+          />
+        </div> 
+        <div className="flex-1"></div>        
+        <div className="flex-1 text-center min-w-0">
+          <h3 className="text-lg font-medium truncate">Hyper Text Markup Language</h3>
+          <div className="flex gap-2 text-sm text-gray-600 justify-center flex-wrap">
+            <span className="whitespace-nowrap">Questions: {skill.totalQuestions}</span>
+            <span className="whitespace-nowrap">Duration: {skill.duration}</span>
+            <span className="whitespace-nowrap">Submitted: {skill.submittedDate}</span>
+          </div>
+        </div>
+        <div className="flex-1"></div>
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 whitespace-nowrap"
+        >
+          Update
+        </button>
+      </div>
+
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-transparent flex items-center justify-center">
+          <div className="bg-white p-6 rounded-lg shadow-lg w-96">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-medium">Update Scores</h3>
+              <Image
+                src={skill.icon}
+                alt={`${skill.name} Icon`}
+                width={30}
+                height={30}
+                className="object-contain"
+              />
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium">Update Your Rank</label>
+                <input
+                  type="number"
+                  name="rank"
+                  value={formData.rank}
+                  onChange={handleInputChange}
+                  className="w-full p-2 border rounded"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium">Update Your Percentile</label>
+                <input
+                  type="number"
+                  name="percentile"
+                  value={formData.percentile}
+                  onChange={handleInputChange}
+                  className="w-full p-2 border rounded"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium">
+                  Update Your Current Score (out of {skill.totalQuestions})
+                </label>
+                <input
+                  type="number"
+                  name="correctAnswers"
+                  value={formData.correctAnswers}
+                  onChange={handleInputChange}
+                  max={skill.totalQuestions}
+                  className="w-full p-2 border rounded"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                onClick={() => setIsModalOpen(false)}
+                className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SkillOverview;

--- a/skill-analytics-dashboard/src/data/skillData.js
+++ b/skill-analytics-dashboard/src/data/skillData.js
@@ -2,7 +2,7 @@ export const skillData = [
   {
     id: 1,
     name: 'HTML',
-    icon: '/html-icon.png',
+    icon: '/HTML-icon.png',
     totalQuestions: 15,
     duration: '30 mins',
     submittedDate: '2025-04-25',


### PR DESCRIPTION

- Fixed middle content overflow on small screens by using a flex layout with spacers (flex-1) to center the title and stats, added truncate and flex-wrap for responsiveness.
- Made the modal background completely transparent (bg-transparent) to ensure the SkillTest page UI remains fully visible without any dimming effect.
- Note: Hydration error due to browser extension attributes on <body> tag is present but skipped for now; to be addressed later.

![Screenshot 2025-04-30 134354](https://github.com/user-attachments/assets/7ce75ec4-ebe1-455e-bc37-fdbc5584c97d)
